### PR TITLE
fix(trimObject): Ignore __proto__ keys that are passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = {
     var out = {};
     for (var i = 0; i < keys.length; i++) {
       var val = obj[keys[i]];
-      if (val === '' || val === null || val === undefined) continue;
+      // Ignore __proto__ to avoid prototype pollution
+      if (val === '' || val === null || val === undefined || val === '__proto__') continue;
       out[keys[i]] = val;
     }
     return out;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmex-shared",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Performant utilty fns in use by BitMEX.",
   "main": "index.js",
   "license": "UNLICENSED",


### PR DESCRIPTION
This protects against objects that have been parsed with `JSON.parse` which will include `__proto__` as a key.

Relatively low risk vector, but better to be safe than sorry I guess.